### PR TITLE
Fix polygon grouped_daily url path

### DIFF
--- a/alpaca_trade_api/polygon/rest.py
+++ b/alpaca_trade_api/polygon/rest.py
@@ -210,7 +210,7 @@ class REST(object):
         return Aggsv2(raw)
 
     def grouped_daily(self, date, unadjusted: bool = False) -> Aggsv2Set:
-        path = f'/aggs/grouped/locale/US/market/STOCKS/{date}'
+        path = f'/aggs/grouped/locale/us/market/stocks/{date}'
         params = {'unadjusted': unadjusted}
         raw = self.get(path, params, version='v2')
         return Aggsv2Set(raw)


### PR DESCRIPTION
STOCKS and US in url must be lowercase or else 404
404: https://api.polygon.io/v2/aggs/grouped/locale/US/market/STOCKS/2020-12-21?apiKey=XXX
200: https://api.polygon.io/v2/aggs/grouped/locale/us/market/stocks/2020-12-21?apiKey=XXX